### PR TITLE
[UX] Improve browsing experience in sidebar

### DIFF
--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -152,8 +152,8 @@ KeyScheme.prototype.computeSourceKey = function(source) {
  * @param {string} reader - name of the source reader
  */
 function BmcComicSource(name, reader) {
-    this._name = name;
-    this._reader = reader;
+    this.name = name;
+    this.reader = reader;
 }
 
 /**
@@ -166,8 +166,8 @@ function BmcComicSource(name, reader) {
  */
 BmcComicSource.prototype.serialize = function() {
     return JSON.stringify({
-        name: this._name,
-        reader: this._reader,
+        name: this.name,
+        reader: this.reader,
     });
 }
 
@@ -197,7 +197,7 @@ BmcComicSource.deserialize = function(str) {
  * @returns {boolean} whether the two sources match
  */
 BmcComicSource.prototype.is = function(source) {
-    return this._name == source._name && this._reader == source._reader;
+    return this.name == source.name && this.reader == source.reader;
 }
 
 
@@ -217,10 +217,10 @@ BmcComicSource.prototype.is = function(source) {
  *                                     this comic
  */
 function BmcComic(label, id, chapter, page, sources) {
-    this._label = label;
-    this._id = id;
-    this._chapter = chapter;
-    this._page = page;
+    this.label = label;
+    this.id = id;
+    this.chapter = chapter;
+    this.page = page;
     this._sources = [];
     if (sources) {
         this._sources = source.splice(0);
@@ -237,11 +237,11 @@ function BmcComic(label, id, chapter, page, sources) {
  */
 BmcComic.prototype.serialize = function() {
     return {
-        label: this._label,
-        id: this._id,
+        label: this.label,
+        id: this.id,
         tracking: {
-            chapter: this._chapter,
-            page: this_page,
+            chapter: this.chapter,
+            page: this.page,
         },
     };
 }
@@ -273,7 +273,7 @@ BmcComic.deserialize = function(obj) {
  * @param {string} label - the new label for the comic entry
  */
 BmcComic.prototype.setLabel = function(label) {
-    this._label = label;
+    this.label = label;
 }
 
 /**
@@ -286,8 +286,8 @@ BmcComic.prototype.setLabel = function(label) {
  * @param {number|undefined} page - the last page read
  */
 BmcComic.prototype.setProgress = function(chapter, page) {
-    this._chapter = chapter;
-    this._page = page;
+    this.chapter = chapter;
+    this.page = page;
 }
 
 /**
@@ -568,7 +568,7 @@ BmcDataAPI.prototype.list = function(cb) {
         // the BmcComic objects.
         const results = keys.map(key => {
             const comic = BmcComic.deserialize(data[key]);
-            inverseMap[comic._id].forEach(source => comic.addSource(source));
+            inverseMap[comic.id].forEach(source => comic.addSource(source));
             return comic;
         });
         return cb(null, results);

--- a/web-extensions/chrome/scripts/load-bookmarks.js
+++ b/web-extensions/chrome/scripts/load-bookmarks.js
@@ -13,6 +13,38 @@ BmcMangaList.prototype.onEntryClick = function(comicId) {
     window.top.postMessage({comicId}, '*');
 }
 
+BmcMangaList.prototype.generateComic = function(comic) {
+    const elm = document.createElement('ul');
+    elm.classList.toggle('mangaListItem');
+
+    const comicElem = document.createElement('li');
+    elm.appendChild(comicElem);
+
+    const comicDiv = document.createElement('div');
+    comicElem.appendChild(comicDiv);
+
+    const comicLabel = document.createElement('span');
+    comicLabel.classList.toggle('rollingArrow');
+    comicLabel.innerText = comic.label;
+    comicLabel.onclick = () => {
+        comicDiv.parentElement.querySelector('.nested').classList.toggle('active');
+        comicLabel.classList.toggle('rollingArrow-down');
+    }
+    comicDiv.appendChild(comicLabel);
+
+    const comicSrcList = document.createElement('ul');
+    comicSrcList.classList.toggle('nested');
+    comicElem.appendChild(comicSrcList);
+
+    comic.iterSources(source => {
+        const srcElem = document.createElement('div');
+        srcElem.innerText = source.reader;
+        comicSrcList.appendChild(srcElem);
+    });
+
+    return elm;
+}
+
 BmcMangaList.prototype.generate = function() {
     var bookmarks = [
         {label: "naruto",           id: 0},
@@ -24,12 +56,16 @@ BmcMangaList.prototype.generate = function() {
 
     console.log("generating bookmark list");
     var mangaList = document.getElementById("manga-list");
-    for (var i = 0; i < bookmarks.length; ++i) {
-        var manga = document.createElement('div');
-        manga.innerText = bookmarks[i].label;
-        manga.onclick = () => this.onEntryClick(bookmarks[i].id);
-        mangaList.appendChild(manga);
-    }
+    bookmarks.forEach(bkmk => {
+        comic = new BmcComic(bkmk.label, bkmk.id, 3, 21);
+        comic.addSource(new BmcComicSource(bkmk.label, 'mangaeden'));
+        comic.addSource(new BmcComicSource(bkmk.label, 'mangafox'));
+        comic.addSource(new BmcComicSource(bkmk.label, 'mangahere'));
+        comic.addSource(new BmcComicSource(bkmk.label, 'mangareader'));
+        console.warn('fake comic generated for', bkmk.label);
+        mangaList.appendChild(this.generateComic(comic))
+        console.warn('fake comic added for', bkmk.label);
+    });
 }
 
 BmcMangaList.prototype.hideEntry = function(entry) {

--- a/web-extensions/chrome/sidebar.html
+++ b/web-extensions/chrome/sidebar.html
@@ -3,19 +3,6 @@
   <head>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' filesystem: ; object-src 'self'; ">
     <style>
-      #searchbox {
-        width: calc(100vw - 10px);
-        border-right: 1px solid #ccc;
-        top: 0;
-        background-color: #fdfdfd;
-        left: 0;
-      }
-      #searchbox > div {
-        font-size: 14px;
-        padding: 5px;
-        border-bottom: 1px solid #ccc;
-        cursor: text;
-      }
       #side-panel {
         width: calc(100vw - 16px);
         border-right: 1px solid #ccc;
@@ -40,6 +27,19 @@
       }
       #hide-but:hover {
         background-color: #ebebeb;
+      }
+      #searchbox {
+        width: calc(100vw - 22px);
+        border-right: 1px solid #ccc;
+        top: 0;
+        background-color: #fdfdfd;
+        left: 0;
+      }
+      #searchbox > div {
+        font-size: 14px;
+        padding: 5px;
+        border-bottom: 1px solid #ccc;
+        cursor: text;
       }
       #manga-list > ul, #manga-list > ul > div {
         padding: 0;

--- a/web-extensions/chrome/sidebar.html
+++ b/web-extensions/chrome/sidebar.html
@@ -26,15 +26,6 @@
         background-color: #fcfcfc;
         left: 0;
       }
-      #manga-list > div {
-        font-size: 14px;
-        padding: 5px;
-        border-bottom: 1px solid #ccc;
-        cursor: pointer;
-      }
-      #manga-list > div:hover {
-        background-color: #ccf;
-      }
       #hide-but {
         position: absolute;
         top: 100px;
@@ -49,6 +40,41 @@
       }
       #hide-but:hover {
         background-color: #ebebeb;
+      }
+      #manga-list > ul, #manga-list > ul > div {
+        padding: 0;
+        margin: 0;
+      }
+      #manga-list div {
+        font-size: 14px;
+        padding: 5px;
+        border-bottom: 1px solid #ccc;
+        cursor: pointer;
+      }
+      #manga-list div:hover {
+        background-color: #ccf;
+      }
+      ul, .mangaListItem {
+        list-style-type: none;
+      }
+      .rollingArrow {
+        cursor: pointer;
+        user-select: none;
+      }
+      .rollingArrow::before {
+        content: "\25B6";
+        color: black;
+        display: inline-block;
+        margin-right: 6px;
+      }
+      .rollingArrow-down::before {
+        transform: rotate(90deg);
+      }
+      .nested {
+        display: none;
+      }
+      .active {
+        display: block;
       }
     </style>
     <script src="engine/storage.js"></script>


### PR DESCRIPTION
This PR provides a tree-like structure for the comics and their sources, so that it's easy to navigate between them.

Currently, the UI is not linked to any further feature (such as "open link in current tab"). and is mostly visual/aesthetic.

So here we go:

Default view after clicking on the infobar button or the sidebar-toggle-button:
![sidebar-tree-default](https://user-images.githubusercontent.com/404509/47660070-8d7a9b00-db96-11e8-965e-08e80b06ff1e.png)

Unrolling the sources for one comic (Note that the cursor is hovering over the manga name, and highlights it):
![sidebar-tree-unrolled-name-hover](https://user-images.githubusercontent.com/404509/47660114-a1260180-db96-11e8-98dd-1d4ac8139d1d.png)

But hovering over a source also highlights it:
![sidebar-tree-unrolled-source-hover](https://user-images.githubusercontent.com/404509/47660194-cd418280-db96-11e8-939f-11e3bb5722f0.png)


Finally, see how it integrates with the searchbox filtering feature:
![sidebar-tree-filtering](https://user-images.githubusercontent.com/404509/47660219-e0ece900-db96-11e8-91a6-a6c630ab7225.png)

That being said, the filtering now selects entries who's source names match, as shows the following picture. I think I'll fix that before going forward with this work:
![sidebar-tree-filtering-bug](https://user-images.githubusercontent.com/404509/47660315-08dc4c80-db97-11e8-800b-de572d524473.png)

