### PR TITLE
[UI] Fix the sidebar toggling when clicking the Register button

### DIFF
--- a/web-extensions/chrome/scripts/register-diag.js
+++ b/web-extensions/chrome/scripts/register-diag.js
@@ -13,9 +13,14 @@ document.getElementById('register').addEventListener('click', () => {
     let sideFrame = null;
     for (var i = 0; i < window.parent.length; ++i) {
         var frame = window.parent.frames[i];
-        if (frame.showHideSidePanel) {
-            sideFrame = frame;
-            break ;
+        try {
+            if (frame.showHideSidePanel) {
+                console.warn(`Frame i=${i} has showHideSidePanel function`);
+                sideFrame = frame;
+                break ;
+            }
+        } catch(e) {
+            continue ;
         }
     }
     // Change the SidePanel mode to "register" then display it


### PR DESCRIPTION
The bug was caused by a naive implementation of a search loop for the sidebar's
frame in the top window's frames.
Adding exception handling to this code does the trick, and prevents the
iframes from different origins from breaking the logic.

Fixes #9