### PR TITLE
Functional Registration/Aliasing, Tracking, and Listing

### DIFF
--- a/web-extensions/chrome/engine/bookmycomics.js
+++ b/web-extensions/chrome/engine/bookmycomics.js
@@ -150,19 +150,38 @@ BmcEngine.prototype.track = function() {
 /*
  * This function registers a comic into the saved data. It shall be used by the
  * user-interacting UI spawned on an online reader's page.
+ *
+ * @param {String} label - the Comic's user-defined label
+ *
+ * @return {undefined}
  */
-BmcEngine.prototype.register = function() {
-    console.log(`BookMyComic: bmcEngine.register: manga=${this._comic.name} chapter=${this._comic.chapter} page=${this._comic.page}`);
-    this.dispatchEvent(new CustomEvent(this.events.register.complete));
+BmcEngine.prototype.register = function(label) {
+    console.log(`BookMyComic: bmcEngine.register: label=${label} reader=${this._comic.reader} manga=${this._comic.name} chapter=${this._comic.chapter} page=${this._comic.page}`);
+    return this._db.registerComic(label, this._comic.reader, this._comic.name, this._comic.chapter, this._comic.page, err => {
+        console.warn(`Register completed with ERR=${err}`);
+        if (err) {
+            return this.dispatchEvent(new CustomEvent(this.events.register.error, {detail: err}));
+        }
+        return this.dispatchEvent(new CustomEvent(this.events.register.complete));
+    });
 };
 
 /*
  * This function registers a new name for an existing comic into the saved data.
  * Then, it also updates the progress of reading for this comic.
+ *
+ * @param {Number} comicId - Unique comic ID
+ *
+ * @return {undefined}
  */
-BmcEngine.prototype.alias = function() {
-    console.log(`BookMyComic: bmcEngine.alias: manga=${this._comic.name} chapter=${this._comic.chapter} page=${this._comic.page}`);
-    this.dispatchEvent(new CustomEvent(this.events.alias.complete));
+BmcEngine.prototype.alias = function(comicId) {
+    console.log(`BookMyComic: bmcEngine.alias: id=${comicId} reader=${this._comic.reader} manga=${this._comic.name}`);
+    return this._db.aliasComic(comicId, this._comic.reader, this._comic.name, err => {
+        if (err) {
+            return this.dispatchEvent(new CustomEvent(this.events.alias.error, {detail: err}));
+        }
+        return this.dispatchEvent(new CustomEvent(this.events.alias.complete));
+    });
 };
 
 /*

--- a/web-extensions/chrome/engine/bookmycomics.js
+++ b/web-extensions/chrome/engine/bookmycomics.js
@@ -5,10 +5,11 @@
  *
  * @class BmcEngine
  */
-function BmcEngine(readerName, comicName, chapter, page) {
+function BmcEngine(hostOrigin, readerName, comicName, chapter, page) {
+    this._hostOrigin = hostOrigin;
     this._db = new BmcDataAPI();
     console.log('Instanciated BmcDataAPI');
-    this._messaging = new BmcMessagingHandler();
+    this._messaging = new BmcMessagingHandler(this._hostOrigin);
     console.log('Instanciated BmcMEssagingHandler');
     this._ui = new BmcUI(this._messaging, this._db);
     console.log('Instanciated BmcUI');
@@ -111,7 +112,7 @@ BmcEngine.prototype._memoizeComic = function () {
 BmcEngine.prototype.setup = function() {
     return this._ui.makeSidePanel(
         () => this.track(),
-        this._comic.name, this._comic.chapter, this._comic.page);
+        this._hostOrigin, this._comic.name, this._comic.chapter, this._comic.page);
 }
 
 /*

--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -472,7 +472,7 @@ BmcDataAPI.prototype.registerComic = function(label, readerName, comicName,
 
             const comicKey = this._scheme.keyFromId(id);
             const dataset = {};
-            dataset[comicKey] = BmcComic.serialize();
+            dataset[comicKey] = comic.serialize();
 
             const source = new BmcComicSource(comicName, readerName);
             const sourceKey = this._scheme.computeSourceKey(source);

--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -373,7 +373,7 @@ function BmcDataAPI() {
  *
  */
 BmcDataAPI.prototype.findComic = function(readerName, comicName, cb) {
-    let source = new BmcComicSource(readerName, comicName);
+    let source = new BmcComicSource(comicName, readerName);
     return this._scheme.idFromSource(source, (err, id) => {
         if (err) {
             console.log(`Got FIND error: ${JSON.stringify(err)}`);
@@ -474,7 +474,7 @@ BmcDataAPI.prototype.registerComic = function(label, readerName, comicName,
             const dataset = {};
             dataset[comicKey] = BmcComic.serialize();
 
-            const source = new BmcComicSource(readerName, comicName);
+            const source = new BmcComicSource(comicName, readerName);
             const sourceKey = this._scheme.computeSourceKey(source);
             map[sourceKey] = id;
             dataset[this._scheme.BMC_MAP_KEY] = map;
@@ -504,7 +504,7 @@ BmcDataAPI.prototype.registerComic = function(label, readerName, comicName,
  */
 BmcDataAPI.prototype.aliasComic = function(comicId, readerName, comicName, cb) {
     return this._scheme.getMap((err, map) => {
-        const source = new BmcComicSource(readerName, comicName);
+        const source = new BmcComicSource(comicName, readerName);
         const sourceKey = this._scheme.computeSourceKey(source);
         map[sourceKey] = comicId;
         const dataset = {};

--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -169,10 +169,8 @@ function BmcComicSource(name, reader) {
  * @return {object}
  */
 BmcComicSource.prototype.serialize = function() {
-    return JSON.stringify({
-        name: this.name,
-        reader: this.reader,
-    });
+    // Ensure ordre by using a template string.
+    return JSON.stringify(this, ['reader', 'name']);
 }
 
 /**

--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -249,17 +249,24 @@ BmcComic.prototype.serialize = function() {
 }
 
 /**
+ * @callback BmcComic~iterCb
+ *
+ * @param {BmcComicSource}
+ *
+ * @return {undefined}
+ */
+/**
  * This method loops over sources.
  *
- * @param {object} callback - The callback to be called on each source.
+ * @param {BmcComic~iterCb} iterFunc - The callback to be called on each source.
  *
  */
-BmcComic.prototype.iterSources = function(callback) {
-    if (!callback) {
+BmcComic.prototype.iterSources = function(iterFunc) {
+    if (!iterFunc) {
         return;
     }
     for (var i = 0; i < this._sources.length; ++i) {
-        callback(this._sources[i]);
+        iterFunc(this._sources[i]);
     }
 }
 

--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -73,9 +73,13 @@ KeyScheme.prototype.nextId = function(cb) {
         if (err) {
             return cb(err, null);
         }
+        // Default value since the first time it'll be `undefined`
+        state = state || { lastId: -1 };
         const nextId = state.lastId + 1;
         state.lastId += 1;
-        this._storage.set(this.BMC_STATE_KEY, state, err => {
+        const dataset = {};
+        dataset[this.BMC_STATE_KEY] = state;
+        this._storage.set(dataset, err => {
             if (err) {
                 return cb(err, null);
             }
@@ -94,7 +98,7 @@ KeyScheme.prototype.nextId = function(cb) {
  *
  */
 KeyScheme.prototype.keyFromId = function(comicId) {
-    return `${BMC_KEY_PREFIX}.${comicId}`;
+    return `${this.BMC_KEY_PREFIX}.${comicId}`;
 };
 
 /**

--- a/web-extensions/chrome/engine/datamodel.js
+++ b/web-extensions/chrome/engine/datamodel.js
@@ -594,6 +594,7 @@ BmcDataAPI.prototype.list = function(cb) {
                 acc[comicId] = [];
             }
             acc[comicId].push(BmcComicSource.deserialize(key));
+            return acc;
         }, {});
         const keys = Object.keys(data).filter(
             key => key.indexOf(this._scheme.BMC_KEY_PREFIX) !== -1

--- a/web-extensions/chrome/engine/messaging.js
+++ b/web-extensions/chrome/engine/messaging.js
@@ -63,9 +63,15 @@ function BmcMessageHandler(tag, selector, handler) {
  *
  * @class
  *
+ * @params {string|undefined} topOrigin - if any, the origin of the topWindow,
+ *            to allow accepting messages from it additionally to internal
+ *            web-extension messages. This allows exchanging between host
+ *            window and web-extension iframes.
+ *
  */
-function BmcMessagingHandler() {
+function BmcMessagingHandler(topOrigin) {
     this._setup = false;
+    this._topOrigin = topOrigin;
 }
 
 /**
@@ -91,7 +97,7 @@ BmcMessagingHandler.prototype.setupMessaging = function() {
             /*
              * NOTE
              * Origin is actually shown as the extension's internal URL, so
-                 * let's retrieve it using runtime.getURL(''); and compare the
+             * let's retrieve it using runtime.getURL(''); and compare the
              * origin against it.
              * Note that the origin does not include an ending '/' while the
              * URL of the extension does, hence the 'indexOf' method rather
@@ -99,7 +105,7 @@ BmcMessagingHandler.prototype.setupMessaging = function() {
              */
             var bro = getBrowser();
             var bmcOrigin = bro.runtime.getURL('');
-            if (bmcOrigin.indexOf(event.origin) !== -1) {
+            if (bmcOrigin.indexOf(event.origin) !== -1 || event.origin === this._topOrigin) {
                 var eventData = event.data;
                 if (typeof(eventData) !== 'object') {
                      console.warn('BmcMessagingHandler: EventData is of unexpected type');

--- a/web-extensions/chrome/engine/ui.js
+++ b/web-extensions/chrome/engine/ui.js
@@ -99,12 +99,13 @@ BmcUI.prototype.removeRegisterDialog = function() {
     this._messaging.removeWindowHandlers(this.INFOBAR_ID);
 };
 
-BmcUI.prototype.makeSidePanel = function(setupTracker, comicName, chapter, page) {
+BmcUI.prototype.makeSidePanel = function(setupTracker, hostOrigin, comicName, chapter, page) {
     var bro = getBrowser();
+    const origin = encodeURIComponent(hostOrigin);
     const rName = encodeURIComponent(window.location.hostname);
     const cName = encodeURIComponent(comicName);
     this.buildSidePanel(setupTracker, bro.runtime.getURL('sidebar.html')
-        + `?reader=${rName}&comicName=${cName}&chapter=${chapter}&page=${page}`);
+        + `?hostOrigin=${origin}&reader=${rName}&comicName=${cName}&chapter=${chapter}&page=${page}`);
 };
 
 BmcUI.prototype.removeSidePanel = function() {

--- a/web-extensions/chrome/engine/ui.js
+++ b/web-extensions/chrome/engine/ui.js
@@ -101,9 +101,10 @@ BmcUI.prototype.removeRegisterDialog = function() {
 
 BmcUI.prototype.makeSidePanel = function(setupTracker, comicName, chapter, page) {
     var bro = getBrowser();
-    const reader = window.location.hostname;
+    const rName = encodeURIComponent(window.location.hostname);
+    const cName = encodeURIComponent(comicName);
     this.buildSidePanel(setupTracker, bro.runtime.getURL('sidebar.html')
-        + `?reader=${reader}&comicName=${encodeURIComponent(comicName)}&chapter=${chapter}&page=${page}`);
+        + `?reader=${rName}&comicName=${cName}&chapter=${chapter}&page=${page}`);
 };
 
 BmcUI.prototype.removeSidePanel = function() {

--- a/web-extensions/chrome/engine/ui.js
+++ b/web-extensions/chrome/engine/ui.js
@@ -115,9 +115,13 @@ BmcUI.prototype.removeSidePanel = function() {
 };
 
 BmcUI.prototype.makeTrackingNotification = function(err) {
-    if (err) {
-        alert('BookMyComic: BmcUI.makeTrackingNotification: Could not save comic progress: ' + err.message);
-        return ;
-    }
-    alert('BookMyComic: BmcUI.makeTrackingNotification: progress saved');
+    var evData = {
+        type: "action",
+        action: "notification",
+        operation: "track",
+        error: err,
+    };
+    const sidepanel = document.getElementById(this.SIDEPANEL_ID);
+    console.log(`BmcUi: Sending message to SidePanel for notification display`);
+    sidepanel.contentWindow.postMessage(evData, '*');
 };

--- a/web-extensions/chrome/entrypoint.js
+++ b/web-extensions/chrome/entrypoint.js
@@ -19,7 +19,8 @@ if (window.top === window) {
      * this work-around of the undefined `work` object, to only provide
      * undefined values instead of the parameters.
      */
-    const engine = new BmcEngine(window.location.hostname,
+    const engine = new BmcEngine(window.location.origin,
+                                 window.location.hostname,
                                  (work || {}).manga,
                                  (work || {}).chapter,
                                  (work || {}).page);

--- a/web-extensions/chrome/manifest.json
+++ b/web-extensions/chrome/manifest.json
@@ -3,6 +3,11 @@
     "version": "0.1",
     "description": "A slightly intrusive extension to keep track of your comics/manga reading progress",
     "manifest_version": 2,
+    "applications": {
+        "gecko": {
+            "id": "support@bookmycomics.org"
+        }
+    },
     "content_scripts": [
         {
             "matches": ["https://www.mangaeden.com/en/en-manga/*"],

--- a/web-extensions/chrome/scripts/load-bookmarks.js
+++ b/web-extensions/chrome/scripts/load-bookmarks.js
@@ -141,6 +141,21 @@ function addEvents(mangaList) {
         var str = sbox.value;
         mangaList.filter(str);
     };
+
+    // On Register-but click, Trigger a new comic registration
+    var but = document.getElementById('register-but');
+    but.onclick = function() {
+        const label = sbox.value;
+        // Sanitize the data first
+        if (sbox.value.length <= 0) {
+            alert("BookMyComics does not support empty labels to identify a comic.<br>"
+                  + "Please define a label in the Side Panel's text area first.");
+        }
+
+        // Now do the actual registration
+        // FIXME TODO FIXME
+    };
+
 }
 
 var mangaList = new BmcMangaList();
@@ -148,28 +163,33 @@ mangaList.generate();
 addEvents(mangaList);
 
 
-function showHideSidePanel() {
+function showHideSidePanel(mode) {
     var evData = {
         type: "action",
         action: null,
     };
-    var btn = document.getElementById('hide-but');
+    var togBtn = document.getElementById('hide-but');
+    var regBtn = document.getElementById('register-but');
     var panel = document.getElementById("side-panel");
     if (panel.style.display === "none") {
+        mangaList.setMode(mode || mangaList.MODE_BROWSE);
         evData.action = "ShowSidePanel",
         panel.style.display = '';
         panel.style.width = 'calc(100vw - 16px)';
-        btn.innerText = '<';
-        btn.style.left = '';
-        btn.style.right = '0';
+        if (mode === mangaList.MODE_REGISTER) {
+            regBtn.style.display = '';
+        }
+        togBtn.innerText = '<';
+        togBtn.style.left = '';
+        togBtn.style.right = '0';
     } else {
-        mangaList.setMode(mangaList.MODE_BROWSE);
         evData.action = "HideSidePanel",
         panel.style.display = 'none';
         panel.style.width = '0';
-        btn.innerText = '>';
-        btn.style.left = '0';
-        btn.style.right = 'initial';
+        regBtn.style.display = 'none';
+        togBtn.innerText = '>';
+        togBtn.style.left = '0';
+        togBtn.style.right = 'initial';
     }
     // Notify top window of the SidePanel action
     window.top.postMessage(evData, '*');

--- a/web-extensions/chrome/scripts/load-bookmarks.js
+++ b/web-extensions/chrome/scripts/load-bookmarks.js
@@ -1,16 +1,30 @@
 const uriParams = document.location.search.split('?')[1].split('&');
-const comicName = decodeURI(uriParams[0].split('=')[1]);
-const chapter = uriParams[1].split('=')[1];
-const page = uriParams[2].split('=')[1];
-console.log(`BmcSideBar: comic ${comicName}, chapter=${chapter}, page=${page}`);
+const readerName = decodeURI(uriParams[0].split('=')[1]);
+const comicName = decodeURI(uriParams[1].split('=')[1]);
+const chapter = uriParams[2].split('=')[1];
+const page = uriParams[3].split('=')[1];
+console.log(`BmcSideBar: reader=${readerName}, comic=${comicName}, chapter=${chapter}, page=${page}`);
 
 function BmcMangaList() {
     this._node = document.getElementById('manga-list');
+    this._mode = BmcMangaList.MODE_BROWSE;
 }
 
+BmcMangaList.prototype.MODE_REGISTER = 'register';
+BmcMangaList.prototype.MODE_BROWSE = 'browse';
+
 BmcMangaList.prototype.onEntryClick = function(comicId) {
-    console.log('clickedOnManga!');
-    window.top.postMessage({comicId}, '*');
+    console.log('clickedOnManga!, mode=' + this._mode);
+    switch (this._mode) {
+    case BmcMangaList.prototype.MODE_REGISTER:
+        this.onAliasClick(comicId);
+        break ;
+    case BmcMangaList.prototype.MODE_BROWSE:
+        // Find a source for the manga and change the URL to that.
+        break ;
+    default:
+        break ;
+    }
 }
 
 BmcMangaList.prototype.generateComic = function(comic) {
@@ -68,6 +82,18 @@ BmcMangaList.prototype.generate = function() {
     });
 }
 
+BmcMangaList.prototype.setMode = function(mode) {
+    switch (mode) {
+    case BmcMangaList.prototype.MODE_REGISTER:
+    case BmcMangaList.prototype.MODE_BROWSE:
+        this._mode = mode;
+        break ;
+    default:
+        console.warn(`BmcSidePanel: BmcMangaList: Unknown MODE "${mode}"`);
+        break ;
+    }
+}
+
 BmcMangaList.prototype.hideEntry = function(entry) {
     entry.style.display = 'none';
 }
@@ -101,32 +127,6 @@ BmcMangaList.prototype.filter = function(filterStr) {
 }
 
 
-function showHideSidePanel() {
-    var evData = {
-        type: "action",
-        action: null,
-    };
-    var btn = document.getElementById('hide-but');
-    var panel = document.getElementById("side-panel");
-    if (panel.style.display === "none") {
-        evData.action = "ShowSidePanel",
-        panel.style.display = '';
-        panel.style.width = 'calc(100vw - 16px)';
-        btn.innerText = '<';
-        btn.style.left = '';
-        btn.style.right = '0';
-    } else {
-        evData.action = "HideSidePanel",
-        panel.style.display = 'none';
-        panel.style.width = '0';
-        btn.innerText = '>';
-        btn.style.left = '0';
-        btn.style.right = 'initial';
-    }
-    // Notify top window of the SidePanel action
-    window.top.postMessage(evData, '*');
-}
-
 function addEvents(mangaList) {
     // Clicking on the  `>`/`<` button will show/hide the panel
     var but = document.getElementById('hide-but');
@@ -146,6 +146,34 @@ function addEvents(mangaList) {
 var mangaList = new BmcMangaList();
 mangaList.generate();
 addEvents(mangaList);
+
+
+function showHideSidePanel() {
+    var evData = {
+        type: "action",
+        action: null,
+    };
+    var btn = document.getElementById('hide-but');
+    var panel = document.getElementById("side-panel");
+    if (panel.style.display === "none") {
+        evData.action = "ShowSidePanel",
+        panel.style.display = '';
+        panel.style.width = 'calc(100vw - 16px)';
+        btn.innerText = '<';
+        btn.style.left = '';
+        btn.style.right = '0';
+    } else {
+        mangaList.setMode(mangaList.MODE_BROWSE);
+        evData.action = "HideSidePanel",
+        panel.style.display = 'none';
+        panel.style.width = '0';
+        btn.innerText = '>';
+        btn.style.left = '0';
+        btn.style.right = 'initial';
+    }
+    // Notify top window of the SidePanel action
+    window.top.postMessage(evData, '*');
+}
 
 // Hide panel by default
 showHideSidePanel();

--- a/web-extensions/chrome/scripts/load-bookmarks.js
+++ b/web-extensions/chrome/scripts/load-bookmarks.js
@@ -1,12 +1,13 @@
 const uriParams = document.location.search.split('?')[1].split('&');
-const readerName = decodeURIComponent(uriParams[0].split('=')[1]);
-const comicName = decodeURIComponent(uriParams[1].split('=')[1]);
-const chapter = uriParams[2].split('=')[1];
-const page = uriParams[3].split('=')[1];
-console.log(`BmcSideBar: comic ${comicName}, chapter=${chapter}, page=${page}`);
+const hostOrigin = decodeURIComponent(uriParams[0].split('=')[1]);
+const readerName = decodeURIComponent(uriParams[1].split('=')[1]);
+const comicName = decodeURIComponent(uriParams[2].split('=')[1]);
+const chapter = uriParams[3].split('=')[1];
+const page = uriParams[4].split('=')[1];
+console.log(`BmcSideBar: origin ${hostOrigin} : comic ${comicName}, chapter=${chapter}, page=${page}`);
 
 console.log('Loading Engine');
-const bmcEngine = new BmcEngine(readerName, comicName, chapter, page);
+const bmcEngine = new BmcEngine(hostOrigin, readerName, comicName, chapter, page);
 
 function BmcMangaList() {
     this._node = document.getElementById('manga-list');

--- a/web-extensions/chrome/scripts/load-bookmarks.js
+++ b/web-extensions/chrome/scripts/load-bookmarks.js
@@ -1,6 +1,6 @@
 const uriParams = document.location.search.split('?')[1].split('&');
-const readerName = decodeURI(uriParams[0].split('=')[1]);
-const comicName = decodeURI(uriParams[1].split('=')[1]);
+const readerName = decodeURIComponent(uriParams[0].split('=')[1]);
+const comicName = decodeURIComponent(uriParams[1].split('=')[1]);
 const chapter = uriParams[2].split('=')[1];
 const page = uriParams[3].split('=')[1];
 console.log(`BmcSideBar: comic ${comicName}, chapter=${chapter}, page=${page}`);

--- a/web-extensions/chrome/scripts/register-diag.js
+++ b/web-extensions/chrome/scripts/register-diag.js
@@ -24,8 +24,7 @@ document.getElementById('register').addEventListener('click', () => {
         }
     }
     // Change the SidePanel mode to "register" then display it
-    sideFrame.mangaList.setMode(sideFrame.mangaList.MODE_REGISTER);
-    sideFrame.showHideSidePanel();
+    sideFrame.showHideSidePanel(sideFrame.mangaList.MODE_REGISTER);
 });
 
 console.log('Register InfoBar setup done.');

--- a/web-extensions/chrome/scripts/register-diag.js
+++ b/web-extensions/chrome/scripts/register-diag.js
@@ -24,6 +24,7 @@ document.getElementById('register').addEventListener('click', () => {
         }
     }
     // Change the SidePanel mode to "register" then display it
+    sideFrame.mangaList.setMode(sideFrame.mangaList.MODE_REGISTER);
     sideFrame.showHideSidePanel();
 });
 

--- a/web-extensions/chrome/sidebar.html
+++ b/web-extensions/chrome/sidebar.html
@@ -41,6 +41,21 @@
         border-bottom: 1px solid #ccc;
         cursor: text;
       }
+      #register-but {
+        position: absolute;
+        top: 0;
+        padding: 1px;
+        background-color: #00aa00;
+        font-size: 16px;
+        right: 0;
+        border: 1px solid #ccc;
+        border-left: none;
+        border-radius: 0 3px 3px 0;
+        cursor: pointer;
+      }
+      #register-but:hover {
+        background-color: #00ff00;
+      }
       #manga-list > ul, #manga-list > ul > div {
         padding: 0;
         margin: 0;
@@ -100,7 +115,8 @@
       <input type="text" placeholder="Search..." id="searchbox"></input>
       <div id="manga-list"></div>
     </div>
-    <div id="hide-but">&lt;</div>
+    <div id="register-but">+</div>
+    <div id="hide-but" class="notif-transform" >&lt;</div>
   </body>
   <script src="scripts/load-bookmarks.js" crossorigin="anonymous"></script>
 </html>

--- a/web-extensions/chrome/sidebar.html
+++ b/web-extensions/chrome/sidebar.html
@@ -28,6 +28,11 @@
       #hide-but:hover {
         background-color: #ebebeb;
       }
+      .notif-transform {
+          transition-property: 'background-color';
+          transition-delay: 0s;
+          transition-duration: 2s;
+      }
       #searchbox {
         width: calc(100vw - 22px);
         border-right: 1px solid #ccc;
@@ -116,7 +121,7 @@
       <div id="manga-list"></div>
     </div>
     <div id="register-but">+</div>
-    <div id="hide-but" class="notif-transform" >&lt;</div>
+    <div id="hide-but">&lt;</div>
   </body>
   <script src="scripts/load-bookmarks.js" crossorigin="anonymous"></script>
 </html>


### PR DESCRIPTION
This PR provides the following features, along with the necessary fixes:
 - Sidebar mode switch between "Browse" (Supposed to allow to jump on the right URL for the comic/source) and "Register" (allows creating new entries + adding sources to existing entries)
 - A new "Register" Button in the sidebar used to validate the creation of a new entry
 - Functional registration of a Comic into the web-extension's storage
 - Functional Aliasing of new sources to an existing Comic from the web-extension's storage
 - Functional Listing of the saved Comics & Sources
 - Visual Notification (Green fading to default color for success, Red fading to default color for failure) through the toggle button, to notify the user of the latest operation's status. Includes:
   - Registration
   - Aliasing
   - Auto-Tracking


Here is the registration process in screenshots:
1. Go to your Comic's page (on a supported reader)
![register_init_state](https://user-images.githubusercontent.com/404509/48589346-66b0b880-e93b-11e8-9388-1778b0c007e8.png)
2. Click on the round `+` button to start the registration process
![register_sidebar](https://user-images.githubusercontent.com/404509/48589351-6ca69980-e93b-11e8-90e8-b2734c68589f.png)
3. Use the searchbox to search for your Comic
![register_sidebar_search](https://user-images.githubusercontent.com/404509/48589357-70d2b700-e93b-11e8-8127-76cff3a1ed77.png)
4. Finalize Registration
4.1. You found it in your tracking list ! Click on the name of the Manga you with to add a source to.
[No Screenshot]
4.2. You could not find it ! Create a new tracking entry by clicking on the "+" button on the side of the searchbox (Hovering over it highlights it)
![register_sidebar_click](https://user-images.githubusercontent.com/404509/48589361-74fed480-e93b-11e8-99a4-110f68806c68.png)

Tracking visual notification:
![track_ui](https://user-images.githubusercontent.com/404509/48589363-792af200-e93b-11e8-9db0-eee5d5558467.png)

Browsing the registered entries in the sidebar (BROWSE mode)
![browse_sidebar](https://user-images.githubusercontent.com/404509/48589369-7defa600-e93b-11e8-9baa-95b6a2a20842.png)


Note that these following screenshots show a few things that remain to do:
Cleanups:
 - Register round Button is still showing after Registration is completed (memoization of the ComicID by the BmcEngine object prevents an update). We need to force this update.

User Experience:
 - The two `+` buttons for registration feel like an unecessary double. We could remove the Infobar completely, and only use the new Registration button instead.
 - Searchbox isn't filled by default when attempting to Register. It could be a cool addition
 - Searchbox content isn't emptied once the SideBar is hidden
 - Searchbox content (if not emptied) is not taken into account for filtering of the Comics when reopening the Sidebar

I've also identified, while testing this, some odd behaviors:
 - All readers do not always trigger a page load when switching from one page to another. I sometimes had mangaeden simply switching URL/picture without loading the page again
   => This might mess-up the auto-tracking if not handled !

And finally, the next steps:
 - Simplify UI where possible
 - Improve UX in general
 - Allows the browse mode to redirect to the Comic/Source's page to go on reading