### PR TITLE
[Sidebar] Fix search to only filter based on Comic Label

### DIFF
--- a/web-extensions/chrome/scripts/load-bookmarks.js
+++ b/web-extensions/chrome/scripts/load-bookmarks.js
@@ -168,7 +168,12 @@ BmcMangaList.prototype.match = function(value, match) {
 BmcMangaList.prototype.filter = function(filterStr) {
     for (var i = 0; i < this._node.childNodes.length; ++i) {
         entry = this._node.childNodes[i];
-        if (this.match(entry.innerText, filterStr)) {
+        // Need to dig through layers to reach the label's text
+        entryLabel = (entry             // ul
+                      .childNodes[0]    // li
+                      .childNodes[0]    // div
+                      .childNodes[0]);  // span == label
+        if (this.match(entryLabel.innerText, filterStr)) {
             this.showEntry(entry);
         } else {
             this.hideEntry(entry);


### PR DESCRIPTION
When the code was modified to list the tracked commits from the storage, we
forgot to update the searching logic, which seemed to work at the time.
As it relies on the DOM's element's innerText, it was actually also including
the string from the Comic's label, which explains why it seemed to work.

Alas, since that innerText also included the reader names (for the alias
listing), searching for a string which matches one reader's name also ended up
selecting all comics wich were referencing that reader, screwing the expected
results.

This commit fixes the situation by ensuring that we only attempt to match the
searchbox's content with the actual label for the Comics.

Fixes #7, introduced by commit ca1bf083