### PR TITLE
Setup full fledged ci With Weekly scheduled full-blown suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,27 @@ jobs:
           paths:
             - venv/
 
+  test-browser-common:
+    executor: browser-testing
+    working_directory: ~/repo
+    steps:
+      - cached-checkout
+      - attach_workspace:
+          at: /tmp/ws
+
+      # Work-around to define env variables from another, for the subsequent
+      # steps.
+      #  - Useful for firefox driver which relies on packaged extension
+      - run:
+          name: Define Packed Webext path
+          command: |
+            echo 'export WEBEXT_DIR="/tmp/ws/build-${BROWSER}"' >> $BASH_ENV
+      - run:
+          name: Setup manifest
+          command: python3 setup.py ${BROWSER}
+      - run:
+          command: /tmp/ws/venv/bin/pytest -v -s --browser ${BROWSER} tests/func/test_00*
+
   test-browser:
     executor: browser-testing
     working_directory: ~/repo
@@ -142,7 +163,7 @@ jobs:
           name: Setup manifest
           command: python3 setup.py ${BROWSER}
       - run:
-          command: /tmp/ws/venv/bin/pytest -v -s --browser ${BROWSER}
+          command: /tmp/ws/venv/bin/pytest -v -s --browser ${BROWSER} --reader ${READER} --ignore-glob='tests/func/test_00*'
 
 workflows:
   version: 2
@@ -150,19 +171,75 @@ workflows:
     jobs:
       - basic-testing
       - setup-testing
-      - build-ext:
+      - build-ext: &build_ff
           name: build-firefox
           context: BookMyComics-Firefox
           requires:
           - basic-testing
-      - test-browser:
-          name: test-firefox
+      - test-browser-common: &common_ff
+          name: test-firefox-common
           context: BookMyComics-Firefox
           requires:
           - build-firefox
           - setup-testing
       - test-browser:
-          name: test-chrome
+          name: test-firefox-mangaeden
+          context: BookMyComics-Firefox-MangaEden
+          requires: &ff_requirements
+          - test-firefox-common
+      - test-browser-common: &common_chrome
+          name: test-chrome-common
           context: BookMyComics-Chrome
           requires:
           - setup-testing
+      - test-browser:
+          name: test-chrome-mangaeden
+          context: BookMyComics-Chrome-MangaEden
+          requires: &chrome_requirements
+          - test-chrome-common
+  weekly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 0"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - basic-testing
+      - setup-testing
+      - build-ext: *build_ff
+      - test-browser-common: *common_ff
+      - test-browser:
+          name: test-firefox-mangaeden
+          context: BookMyComics-Firefox-MangaEden
+          requires: *ff_requirements
+      - test-browser:
+          name: test-firefox-mangahere
+          context: BookMyComics-Firefox-MangaHere
+          requires: *ff_requirements
+      - test-browser:
+          name: test-firefox-mangareader
+          context: BookMyComics-Firefox-MangaReader
+          requires: *ff_requirements
+      - test-browser:
+          name: test-firefox-fanfox
+          context: BookMyComics-Firefox-FanFox
+          requires: *ff_requirements
+      - test-browser-common: *common_chrome
+      - test-browser:
+          name: test-chrome-mangaeden
+          context: BookMyComics-Chrome-MangaEden
+          requires: *chrome_requirements
+      - test-browser:
+          name: test-chrome-mangahere
+          context: BookMyComics-Chrome-MangaHere
+          requires: *chrome_requirements
+      - test-browser:
+          name: test-chrome-mangareader
+          context: BookMyComics-Chrome-MangaReader
+          requires: *chrome_requirements
+      - test-browser:
+          name: test-chrome-fanfox
+          context: BookMyComics-Chrome-FanFox
+          requires: *chrome_requirements

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ def pytest_generate_tests(metafunc):
 
 def pytest_exception_interact(node, call, report):
     controller = node.funcargs['controller']
+    if report.failed:
+        controller.driver.save_screenshot('/tmp/test-failed.png')
     if report.failed and isinstance(controller.driver, webdriver.Chrome):
         # Retrieve test's browser logs through the webdriver
         s = '\n'.join([

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,19 +21,24 @@ def pytest_generate_tests(metafunc):
 
 
 def pytest_exception_interact(node, call, report):
-    controller = node.funcargs['controller']
-    if report.failed:
-        controller.driver.save_screenshot('/tmp/test-failed.png')
-    if report.failed and isinstance(controller.driver, webdriver.Chrome):
-        # Retrieve test's browser logs through the webdriver
-        s = '\n'.join([
-            str(line) for line in
-            controller.driver.get_log('browser')
-        ])
-        if len(s) > 0:
-            print('\n=== CONSOLE LOGS ===')
-            print(s)
-            print('=== END OF CONSOLE LOGS ===')
+    if ('Module' in repr(node)):
+        print('\n=== MODULE ERROR ===')
+        print(node.obj)
+        print('=== END OR MODULE ERROR ===')
+    else:
+        controller = node.funcargs['controller']
+        if report.failed:
+            controller.driver.save_screenshot('/tmp/test-failed.png')
+        if report.failed and isinstance(controller.driver, webdriver.Chrome):
+            # Retrieve test's browser logs through the webdriver
+            s = '\n'.join([
+                str(line) for line in
+                controller.driver.get_log('browser')
+            ])
+            if len(s) > 0:
+                print('\n=== CONSOLE LOGS ===')
+                print(s)
+                print('=== END OF CONSOLE LOGS ===')
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def pytest_generate_tests(metafunc):
         browsers = sorted(set(browsers))
         controllers = [BmcController(drivers.get_driver(browser))
                        for browser in browsers]
-        metafunc.parametrize('controller', controllers)
+        metafunc.parametrize('controller', controllers, ids=browsers)
 
 
 def pytest_exception_interact(node, call, report):

--- a/tests/func/test_010_utilities.py
+++ b/tests/func/test_010_utilities.py
@@ -1,0 +1,12 @@
+import pytest
+
+from .utils.extension import Extension
+from .utils.support import drivers
+
+EXT = Extension()
+
+
+def test_010_utilities(controller, reader_driver):
+    reader_driver.load_random()
+    reader_driver.prev_page()
+    reader_driver.next_page()

--- a/tests/func/utils/__init__.py
+++ b/tests/func/utils/__init__.py
@@ -1,6 +1,33 @@
 from os import path
 from functools import reduce
+import sys
+import time
 
 def make_realpath(pathlist):
     fpath = reduce(lambda p, p2: path.join(p, p2), pathlist, '')
     return path.realpath(fpath)
+
+
+class RetriableError(Exception):
+    def __init__(self, msg):
+        super(RetriableError, self).__init__(msg)
+
+def retry(retries=5, abort=True):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            count = 0
+            while count < retries:
+                try:
+                    if count != 0:
+                        time.sleep(1)
+
+                    return func(*args, **kwargs)
+                except RetriableError as e:
+                    count += 1
+                    print(str(e), file=sys.stderr)
+
+            # Assert if abort is set, when all retries are exhausted
+            assert abort == False
+
+        return wrapper
+    return decorator

--- a/tests/func/utils/bmc.py
+++ b/tests/func/utils/bmc.py
@@ -65,8 +65,8 @@ class SideBarController:
 
 class BmcController:
 
-    def __init__(self, webdriver):
-        self._driver = webdriver
+    def __init__(self, wrapped_webdriver):
+        self._wrapped_driver = wrapped_webdriver
         self._sidebar = None
 
     @property
@@ -76,7 +76,16 @@ class BmcController:
             This is sometimes easier to go through this rather than wrap all
             calls to "hide"
         """
-        return self._driver
+        return self.wrapped_driver.driver
+
+    @property
+    def wrapped_driver(self):
+        """
+            Access the wrapped webdriver.
+            This enables possible use of common utility methods from the
+            wrapper.
+        """
+        return self._wrapped_driver
 
     @property
     def sidebar(self):
@@ -88,5 +97,5 @@ class BmcController:
             when it's necessary (and supposed to be possible).
         """
         if not self._sidebar:
-            self._sidebar = SideBarController(self._driver)
+            self._sidebar = SideBarController(self.driver)
         return self._sidebar

--- a/tests/func/utils/drivers/__init__.py
+++ b/tests/func/utils/drivers/__init__.py
@@ -22,4 +22,4 @@ def get_driver(name):
         WD_WRAPPERS[name] = wrappers[name](Extension())
         wrapper = WD_WRAPPERS[name]
 
-    return wrapper.driver
+    return wrapper

--- a/tests/func/utils/drivers/chrome.py
+++ b/tests/func/utils/drivers/chrome.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from .base import BaseWebdriverWrapper
@@ -17,3 +18,11 @@ class Wrapper(BaseWebdriverWrapper):
 
         self._driver = webdriver.Chrome(options=options,
                                         desired_capabilities=capabilities)
+
+    def ensure_click(self, element):
+        """
+            Ensures that the element is clickable (within viewport) then clicks
+            on it.
+        """
+        ActionChains(self._driver).move_to_element(element).perform()
+        element.click()

--- a/tests/func/utils/drivers/firefox.py
+++ b/tests/func/utils/drivers/firefox.py
@@ -20,3 +20,14 @@ class Wrapper(BaseWebdriverWrapper):
         print('Loading addon from "{}"'.format(self._ext.packed_path))
         self._driver.install_addon(self._ext.packed_path, temporary=True)
         print('Driver installed add-on')
+
+    def ensure_click(self, element):
+        """
+            Ensures that the element is clickable (within viewport) then clicks
+            on it.
+        """
+        loc = element.location
+        wsz = self._driver.get_window_size()
+        js_scroll_command = 'window.scrollTo({},{});' .format(loc['x'] - wsz['width']/2,
+                                                              loc['y'] - wsz['height']/2)
+        self._driver.execute_script(js_scroll_command)

--- a/tests/func/utils/support/__init__.py
+++ b/tests/func/utils/support/__init__.py
@@ -17,9 +17,11 @@ class SupportBase:
 from .mangaeden import MangaEdenDriver
 from .mangahere import MangaHereDriver
 from .mangareader import MangaReaderDriver
+from .mangafox import FanFoxDriver
 
 drivers = {
     MangaEdenDriver.name: MangaEdenDriver,
     MangaHereDriver.name: MangaHereDriver,
     MangaReaderDriver.name: MangaReaderDriver,
+    FanFoxDriver.name: FanFoxDriver,
 }

--- a/tests/func/utils/support/__init__.py
+++ b/tests/func/utils/support/__init__.py
@@ -16,8 +16,10 @@ class SupportBase:
 
 from .mangaeden import MangaEdenDriver
 from .mangahere import MangaHereDriver
+from .mangareader import MangaReaderDriver
 
 drivers = {
     MangaEdenDriver.name: MangaEdenDriver,
     MangaHereDriver.name: MangaHereDriver,
+    MangaReaderDriver.name: MangaReaderDriver,
 }

--- a/tests/func/utils/support/__init__.py
+++ b/tests/func/utils/support/__init__.py
@@ -15,7 +15,9 @@ class SupportBase:
         pass
 
 from .mangaeden import MangaEdenDriver
+from .mangahere import MangaHereDriver
 
 drivers = {
     MangaEdenDriver.name: MangaEdenDriver,
+    MangaHereDriver.name: MangaHereDriver,
 }

--- a/tests/func/utils/support/__init__.py
+++ b/tests/func/utils/support/__init__.py
@@ -1,8 +1,9 @@
 class SupportBase:
     name = None
 
-    def __init__(self, driver, *args, **kwargs):
-        self._driver = driver
+    def __init__(self, wrapped_driver, *args, **kwargs):
+        self._wrapper = wrapped_driver
+        self._driver = wrapped_driver.driver
 
     def load_random(self):
         pass

--- a/tests/func/utils/support/__init__.py
+++ b/tests/func/utils/support/__init__.py
@@ -1,0 +1,17 @@
+class SupportBase:
+    name = None
+
+    def __init__(self, driver, *args, **kwargs):
+        self._driver = driver
+
+    def load_random(self):
+        pass
+
+    def prev_page(self):
+        pass
+
+    def next_page(self):
+        pass
+
+drivers = {
+}

--- a/tests/func/utils/support/__init__.py
+++ b/tests/func/utils/support/__init__.py
@@ -14,5 +14,8 @@ class SupportBase:
     def next_page(self):
         pass
 
+from .mangaeden import MangaEdenDriver
+
 drivers = {
+    MangaEdenDriver.name: MangaEdenDriver,
 }

--- a/tests/func/utils/support/mangaeden.py
+++ b/tests/func/utils/support/mangaeden.py
@@ -1,0 +1,55 @@
+import random
+
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+
+from . import SupportBase
+from .. import RetriableError, retry
+
+class MangaEdenDriver(SupportBase):
+    name = "mangaeden"
+
+    def __init__(self, *args, **kwargs):
+        super(MangaEdenDriver, self).__init__(*args, **kwargs)
+
+    @retry(abort=True)
+    def load_random(self):
+        # First, go to the website
+        self._driver.get('https://www.mangaeden.com/')
+
+        # Retrieve the generated random link, which is generated after loading the page
+        btn = self._driver.find_element(by=By.CLASS_NAME, value='randomize')
+        href = btn.get_attribute('href')
+        self._driver.get(href);
+
+        # Now select randomly a chapter in the list of chapters
+        chapters = self._driver.find_elements(by=By.CLASS_NAME, value='chapterLink')
+        if chapters is None or len(chapters) < 1:
+            raise RetriableError('No chapter link found in manga summary.')
+        chapters[random.randrange(len(chapters))].click()
+        # In some cases, the manga chapters redirect to authentication page. check for it
+        if self._driver.current_url == 'https://www.mangaeden.com/en/login':
+            raise RetriableError('Manga chapter redirected to login page. Cannot work with it.')
+
+        # Now, select a page which has both "next" and "prev" pages
+        # (ie: neither first nor last)
+        try:
+            page_selector = self._driver.find_element(by=By.ID, value='pageSelect')
+        except NoSuchElementException:
+            raise RetriableError('No page selector found in manga chapter')
+        pages = page_selector.find_elements(by=By.TAG_NAME, value='option')
+        if len(pages) <= 2:
+            # This might mean that we're looking at one-page chapters for the
+            # manga. As the reader supports it, let's go with this.
+            return
+        page_selector.click()
+        pages[random.randrange(1, len(pages) - 1)].click()
+
+    def prev_page(self):
+        btn = self._driver.find_element(by=By.CLASS_NAME, value='prev')
+        btn.click()
+
+    def next_page(self):
+        btn = self._driver.find_element(by=By.CLASS_NAME, value='next')
+        btn.click()

--- a/tests/func/utils/support/mangafox.py
+++ b/tests/func/utils/support/mangafox.py
@@ -1,0 +1,144 @@
+import random
+
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+
+from . import SupportBase
+from .. import RetriableError, retry
+
+
+class FanFoxNavBar:
+    def __init__(self, driver_wrapper):
+        self._wrapper = driver_wrapper
+        self._driver = driver_wrapper.driver
+        self._pages = None
+        self._pageIdx = -1
+        self._chapter_prev = None
+        self._chapter_next = None
+        self.update()
+
+    def update(self):
+        # pages = self._driver.find_elements_by_css_selector('div.pager-list-left > span > a')
+        # chapters = self._driver.find_elements_by_css_selector('div.pager-list-left > a.chapter')
+        pager = self._get_pager()
+        if not pager:
+            return False
+
+        self._pages = pager.find_elements_by_css_selector('span > a')
+        chapters = pager.find_elements_by_css_selector('a.chapter')
+        self._chapter_prev = None
+        self._chapter_next = None
+        for button in chapters:
+            if "Pre" in button.text:
+                self._chapter_prev = button
+            if "Next" in button.text:
+                self._chapter_next = button
+
+        self._pageIdx = self._get_current_page_idx()
+        return True
+
+    def _get_pager(self):
+        pagers = self._driver.find_elements(by=By.CLASS_NAME, value='pager-list-left')
+        for i in range(len(pagers)):
+            if pagers[i].get_property('childElementCount') > 0:
+                pager = pagers[i]
+                return pager
+        return None
+
+    def _get_current_page_idx(self):
+        curPageIdx = -1
+        for i in range(len(self._pages)):
+            if 'active' in self._pages[i].get_attribute('class'):
+                curPageIdx = i
+                break
+        return curPageIdx
+
+    def prev_chapter(self):
+        if not self._chapter_prev:
+            return False
+        self._wrapper.ensure_click(self._chapter_prev)
+        return self.update()
+
+    def first_page(self):
+        if not self._pages or self._pageIdx == 0:
+            return False
+        self._wrapper.ensure_click(self._pages[1])
+        return self.update()
+
+    def prev_page(self):
+        if not self._pages or self._pageIdx <= 0:
+            return False
+        self._wrapper.ensure_click(self._pages[0]) # Click on the "<" button
+        return self.update()
+
+    def next_page(self):
+        if not self._pages or self._pageIdx == (len(self._pages) - 1):
+            return False
+        self._wrapper.ensure_click(self._pages[len(self._pages) -1 ]) # Click on the ">" button
+        return self.update()
+
+    def last_page(self):
+        if not self._pages or self._pageIdx == (len(self._pages) - 1):
+            return False
+        self._wrapper.ensure_click(self._pages[len(self._pages) - 2])
+        return self.update()
+
+    def next_chapter(self):
+        if not self._chapter_next:
+            return False
+        self._wrapper.ensure_click(self._chapter_next)
+        return self.update()
+
+
+class FanFoxDriver(SupportBase):
+    name = "mangafox"
+
+    def __init__(self, *args, **kwargs):
+        super(FanFoxDriver, self).__init__(*args, **kwargs)
+        self._navbar = FanFoxNavBar(self._wrapper)
+
+    @retry(abort=True)
+    def load_random(self):
+        # First, go to the website
+        self._driver.get('https://fanfox.net')
+
+        # Then randomly choose one of the "latest" chapters from the home page
+        latest_chapters = self._driver.find_elements_by_css_selector(
+            'p.manga-list-1-item-subtitle > a')
+        self._driver.get(
+            latest_chapters[random.randrange(len(latest_chapters))]
+            .get_attribute('href'))
+        if self._driver.current_url == 'https://fanfox.net':
+            raise RetriableError('Could not load a random "latest" chapter')
+
+        # Now, select a page which has both "next" and "prev" pages (ie:
+        # neither first nor last), but first we need to ensure the DOM has been
+        # properly updated, and that the required select is present (it's added
+        # dynamically)
+        try:
+            pages = self._driver.find_elements_by_css_selector('div > div > span > a')
+        except NoSuchElementException:
+            raise RetriableError('No pages buttons found in manga chapter')
+        if len(pages) <= 2:
+            # This might mean that we're looking at one-page chapters for the
+            # manga. As the reader supports it, let's go with this.
+            self._navbar.update()
+            return
+        # Only retain half the links (the navigation buttons are present twice
+        # in a page, on top of the scan and underneath it).
+        pages = pages[0:int(len(pages)/2)]
+        self._wrapper.ensure_click(pages[random.randrange(1, len(pages) - 1)])
+        self._navbar.update()
+
+    def prev_page(self):
+        if not self._navbar.prev_page():
+            if self._navbar.prev_chapter():
+                if not self._navbar.last_page():
+                    print('Already at earliest page, cannot go to previous')
+                    return
+
+    def next_page(self):
+        if not self._navbar.next_page():
+            if not self._navbar.next_chapter():
+                print('Already at latest chapter, cannot go to next')
+                return

--- a/tests/func/utils/support/mangahere.py
+++ b/tests/func/utils/support/mangahere.py
@@ -1,0 +1,79 @@
+import random
+
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from . import SupportBase
+from .. import RetriableError, retry
+
+
+class MangaHereDriver(SupportBase):
+    name =  "mangahere"
+
+    def __init__(self, *args, **kwargs):
+        super(MangaHereDriver, self).__init__(*args, **kwargs)
+
+    def _get_chapter_url(self):
+        return self._driver.current_url.split('?')[0]
+
+    def _get_link_btn(self, match):
+        btns = self._driver.find_elements_by_css_selector(".loadImgPage.pull-right")
+        for btn in btns:
+            if match == btn.text:
+                return btn
+        return None
+
+    @retry(abort=True)
+    def load_random(self):
+        # First, go to the website
+        self._driver.get('http://mangahere.us')
+
+        # Then randomly choose one of the "latest" chapters from the home page
+        latest_chapters = self._driver.find_elements(by=By.CLASS_NAME, value='xanh')
+        if not latest_chapters:
+            raise RetriableError("No latest chapter found")
+        latest_chapters[random.randrange(len(latest_chapters))].click()
+        if self._driver.current_url == 'http://mangahere.us':
+            raise RetriableError('Could not load a random "latest" chapter')
+
+        # Now, select a page which has both "next" and "prev" pages (ie:
+        # neither first nor last), but first we need to ensure the DOM has been
+        # properly updated, and that the required select is present (it's added
+        # dynamically)
+        try:
+            wait = WebDriverWait(self._driver, 10)
+            wait.until(EC.presence_of_element_located((By.ID, 'page_select')))
+            selector = self._driver.find_element(by=By.ID, value='page_select')
+        except NoSuchElementException:
+            raise RetriableError('No page selector found in manga chapter')
+        options = selector.find_elements_by_tag_name('option')
+        if len(options) <= 2:
+            # This might mean that we're looking at one-page chapters for the
+            # manga. As the reader supports it, let's go with this.
+            return
+        options[random.randrange(1, len(options) - 1)].click()
+
+    def prev_page(self):
+        btn = self._get_link_btn('Prev')
+        if btn:
+            self._wrapper.ensure_click(btn)
+            return
+        # If no prev btn, expect to navigate to previous chapter (then last
+        # page?)
+        if not btn:
+            btn = self._driver.find_element(by=By.CLASS_NAME, value='LeftArrow')
+            self._wrapper.ensure_click(btn)
+            selector = self._driver.find_element(by=By.ID, value='page_select')
+            options = selector.find_elements_by_tag_name('option')
+            selector.select_by_index(len(options) - 1)
+
+    def next_page(self):
+        btn = self._get_link_btn('Next')
+        # If no next btn, expect to navigate to next chapter
+        if not btn:
+            btn = self._driver.find_element(by=By.CLASS_NAME, value='RightArrow')
+        if btn:
+            self._wrapper.ensure_click(btn)

--- a/tests/func/utils/support/mangareader.py
+++ b/tests/func/utils/support/mangareader.py
@@ -1,0 +1,56 @@
+import random
+
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+
+from . import SupportBase
+from .. import RetriableError, retry
+
+class MangaReaderDriver(SupportBase):
+    name = "mangareader"
+
+    def __init__(self, *args, **kwargs):
+        super(MangaReaderDriver, self).__init__(*args, **kwargs)
+
+    @retry(abort=True)
+    def load_random(self):
+        # First, go to the website
+        self._driver.get('https://www.mangareader.net')
+
+        # Then Use the "Surprise Me!" button to randomly choose a manga
+        btn = self._driver.find_element(by=By.PARTIAL_LINK_TEXT, value='Surprise')
+        btn.click()
+
+        # Now, retrieve all chapters links and choose one
+        chapters = self._driver.find_elements_by_css_selector(
+            'table#listing > tbody > tr > td > a')
+        if not chapters:
+            raise RetriableError("No chapter found for random manga")
+        link = chapters[random.randrange(len(chapters))].get_attribute('href')
+        # Need to use the link here, as the click on the element did not work
+        # in the timing the script generated.
+        self._driver.get(link)
+
+        # Finally, retrieve the page selector to choose a random one, ensuring
+        # that we select neither the first nor the last.
+        page_selector = self._driver.find_element(by=By.ID, value='pageMenu')
+        if not page_selector:
+            raise RetriableError("No page selector found")
+        options = page_selector.get_property('options')
+        if not options:
+            raise RetriableError("No options found in the page selector")
+        if len(options) <= 2:
+            # This might mean that we're looking at one-page chapters for the
+            # manga. As the reader supports it, let's go with this.
+            return
+        options[random.randrange(1, len(options) -1)].click()
+
+    def prev_page(self):
+        span = self._driver.find_element(by=By.CLASS_NAME, value='prev')
+        btn = span.find_element(by=By.TAG_NAME, value='a')
+        btn.click()
+
+    def next_page(self):
+        span = self._driver.find_element(by=By.CLASS_NAME, value='next')
+        btn = span.find_element(by=By.TAG_NAME, value='a')
+        btn.click()


### PR DESCRIPTION
This PR provides an important part of the tooling required to write tests, including:
 - Automatic screenshot generation on test failure
 - `--browser [firefox|chrome]` CLI option to run only part of the tests (filter on supported browsers)
 - `--reader [mangaeden|mangareader|mangahere|mangafox]` CLI option to run only part of the tests (filter on supported websites)
 - Fix of the test failure hook (which dumps console log in case of failure for Chrome browser)
 - Add fixtures for each currently supported reader, to load a random manga, and browse its pages (with retries on failures etc.)
 - Add a basic tests which validates the support fixtures
 - Weekly schedule setup of the full-blown test suite


This PR can be either reviewed commit-per-commit, or as a whole. up to the reader.